### PR TITLE
[BUG FIX]: ios 강력한 암호 제안과 관련된 버그 99% 해결 (Choose My Own Password)

### DIFF
--- a/components/AuthInput.tsx
+++ b/components/AuthInput.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { StyleSheet, Text } from "react-native";
+import {
+  NativeSyntheticEvent,
+  Platform,
+  StyleSheet,
+  Text,
+  TextInputEndEditingEventData,
+} from "react-native";
 import { TextInput, View } from "react-native";
 
 interface Props {
@@ -8,6 +14,9 @@ interface Props {
   onChangeText: (text: string) => void;
   placeholder?: string;
   type?: "TEXT" | "PASSWORD";
+  onEndEditing?: (
+    e: NativeSyntheticEvent<TextInputEndEditingEventData>
+  ) => void;
 }
 
 export default function AuthInput({
@@ -16,6 +25,7 @@ export default function AuthInput({
   onChangeText,
   placeholder = "",
   type = "TEXT",
+  onEndEditing,
 }: Props) {
   return (
     <View style={styles.inputView}>
@@ -24,7 +34,15 @@ export default function AuthInput({
         style={styles.input}
         value={value}
         onChangeText={onChangeText}
+        // 애플의 강력한 암호 제안을 취소했을 때
+        // onChangeText가 트리거 되지 않는 문제때문에 onEndEditing으로 임시 해결
+        onEndEditing={onEndEditing}
         secureTextEntry={type === "PASSWORD"}
+        onFocus={() => {
+          if (type === "PASSWORD" && Platform.OS === "ios") {
+            onChangeText("");
+          }
+        }}
         placeholder={placeholder}
       />
     </View>

--- a/screens/SignUp/index.tsx
+++ b/screens/SignUp/index.tsx
@@ -27,6 +27,10 @@ export default function SignUpScreen({ navigation }: Props) {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
+  // Password 입력이 끝났을 때 password와 confirmPassword가 리렌더링 되도록하는 Key 상태값
+  // 리렌더링 이유: IOS 비밀번호 제안 때문에 발생하는 입력 문제
+  const [dateKey, setDateKey] = useState(Date.now());
+
   const handleSignUp = () => {
     if (isLoading) return;
     setIsLoading(true);
@@ -114,13 +118,22 @@ export default function SignUpScreen({ navigation }: Props) {
           placeholder="abc123@gmail.com"
         />
         <AuthInput
+          key={dateKey + "-password"}
           label="Password"
           value={password}
           onChangeText={(v) => setPassword(v)}
           placeholder="1234*#"
           type="PASSWORD"
+          onEndEditing={(e) => {
+            setPassword(e.nativeEvent.text);
+            setDateKey(Date.now());
+            if (confirmPassword !== e.nativeEvent.text) {
+              setConfirmPassword("");
+            }
+          }}
         />
         <AuthInput
+          key={dateKey + "-confirmPassword"}
           label="Confirm Password"
           value={confirmPassword}
           onChangeText={(v) => setConfirmPassword(v)}


### PR DESCRIPTION
# 기존 문제점

https://github.com/ICE0208/journal-with-react-native/assets/46257328/734e7a75-e031-4ee3-b4fb-c426fe097f72

IOS 환경에서 비밀번호를 직접 입력하기 위해 'Choose My Own Password' 옵션을 선택했을 때, 비밀번호 입력칸이 비어 있어 보이다더라도 실제로는 기존에 자동 생성된 비밀번호가 password와 confirmPassword 상태값에 남아있다 버그가 있다.

이러한 상황에서 비밀번호 입력칸을 변경하지 않고 회원가입을 시도하면, 보이지 않는 기존 자동 생성된 비밀번호가 함께 전송된다 회원가입이 완료된다 문제가 발생한다.

# 해결 과정

## 문제점 원인 파악

처음에 암호가 자동으로 생성될 때는 onChangeText가 트리거되어 상태값을 자동으로 생성된 암호로 바꾼다. 하지만 'Choose My Own Password'를 선택했을 때에는 입력칸을 비우지만 onChangeText가 트리거되지 않아서 상태값이 바뀌지 않는다.

```tsx
<AuthInput
  label="Password"
  value={password}
  onChangeText={(v) => setPassword(v)}
  placeholder="1234*#"
  type="PASSWORD"
/>
```

기존에 작성된 코드에서는 onChangeText가 트리거될 때 상태값을 변경하도록 구현했기 때문에, 'Choose My Own Password'를 선택하였을 때 입력칸은 비워지지만 onChangeText가 트리거되지 않아 상태값이 변경되지 않는 점에서 문제가 발생하였다.

## 관련된 이슈 찾기

인터넷으로 조사한 결과, 비슷한 문제점이 react-native 깃허브 이슈에 올라와있었다.
[[ios] "Choose My Own Password" not calling onChange #23921](https://github.com/facebook/react-native/issues/23921)

이 이슈에 코멘트를 살펴보니 완벽하진 않지만 쓸만한 해결책을 찾을 수 있었다.

![image](https://github.com/ICE0208/journal-with-react-native/assets/46257328/d0b677e7-a920-4e4e-a258-ac91e4670f6d)

`onEndEditing` 을 이용하여 해결할 수 있다는 코멘트였다.
해결하기 위해 TextInput에 value와 onChangeText를 지정하지 않고, onEndEditing만 사용하여 시도해보았으나, 특정 상황에서 또 같은 문제가 발생하였다. 그래서 그냥 `value`, `onChangeText`, `onEndEditing` 을 전부 활용하여 어떻게든 해결해보려고 시도했다.

## 변경된 코드

```tsx
<AuthInput
  key={dateKey + "-password"}
  label="Password"
  value={password}
  onChangeText={(v) => setPassword(v)}
  placeholder="1234*#"
  type="PASSWORD"
  onEndEditing={(e) => {
    setPassword(e.nativeEvent.text);
    setDateKey(Date.now());
    if (confirmPassword !== e.nativeEvent.text) {
      setConfirmPassword("");
    }
  }}
/>
<AuthInput
  key={dateKey + "-confirmPassword"}
  label="Confirm Password"
  value={confirmPassword}
  onChangeText={(v) => setConfirmPassword(v)}
  placeholder="1234*#"
  type="PASSWORD"
/>
```

기존 비밀번호와 비밀번호 확인 코드 부분에 `onEndEditing` 을 추가하여 어느정도 (99% 정도?) 해결하였다. 왜 99%인지, 나머지 1%는 어디로 갔는지는 좀 더 아래에서 설명하겠다.

onEndEditing이 트리거 되면 아래와 같은 작업이 수행된다.
### 1. 실제 Input의 값을 상태값으로 지정
```tsx
setPassword(e.nativeEvent.text);
```
password의 실제 Input 값과 상태값을 동일하여 해주었다.

### 2. 비밀번호 관련 Input이 모두 리렌더링 되도록 key값을 업데이트 
```tsx
setDateKey(Date.now());
```
리렌더링 하지 않으면 아래와 같은 문제가 일어난다.

https://github.com/ICE0208/journal-with-react-native/assets/46257328/5b213ec5-9e99-46d5-b78d-4f1c56608685

비밀번호를 입력할 때는 키보드 녹화가 안돼서 잘 안보이지만 일단 강력한 암호를 사용하면 입력칸이 노란색으로 되어 못생겨지고, 다시 비밀번호 Input을 눌러서 `Choose My Own Password` 를 선택할 때까지 아무것도 입력할 수 없는 문제점이 발생한다. 그래서 그냥 키 값을 변경해서 리렌더링을 유발하여 해결했다.

### 3. 강력한 비밀번호를 사용하지 않을 때 confirmPassword를 초기화
```tsx
if (confirmPassword !== e.nativeEvent.text) {
  setConfirmPassword("");
}
```
강력한 비밀번호를 사용한다면 password 값과 confirmPassword이 같을 것이다.
반대로 `Choose My Own Password` 를 선택하여 취소한다면 이 두개의 값이 달라질 것이다.
따라서 조건문을 이용하여 password와 confirmPassword 값이 다를 때 confirmPassword의 값을 초기화해주었다.

# 왜 99% 해결인가?

거의 모든 케이스에서는 문제가 없지만 아주 특수한 상황에서 약간의 문제점이 발생한다.
`Choose My Own Password` 를 누르고 암호를 입력했는데 만약 그 암호가 방금 제안된 암호와 동일한 값이라면???
이 상황에서는 confirmPassword가 초기화되지않고 그대로 남아있다.
심지어 영상에서는 보이지 않지만, 비밀번호 확인 입력칸이 마치 자동으로 채워지는 것처럼 보여지게 된다.

https://github.com/ICE0208/journal-with-react-native/assets/46257328/ca6fb8c3-0fe9-4d90-bdca-7b84416f0905

물론 아주 특수한 상황에서만 발생하는 문제이고, 처음 문제점과 비교하면 아주 미약한 문제이기 때문에 괜찮지만 버그가 있음에도 해결할 아이디어가 떠오르지 않아서 답답하다.

# 결론

많은 시간을 투자했지만 결국 제대로 된 해결책을 찾지 못했고, 겨우 찾은 임시 해결책도 약간의 버그가 존재했다.
이번에는 급하게 완성해야하는 개인 프로젝트이기도 하고, 심각한 버그가 아니기 때문에 일단 보류해두고 나중에 여유될 때 다른 해결책을 찾아보아야겠다. 🙁